### PR TITLE
Update CPArrayImage.scala

### DIFF
--- a/modules/cosplay/src/main/scala/org/cosplay/CPArrayImage.scala
+++ b/modules/cosplay/src/main/scala/org/cosplay/CPArrayImage.scala
@@ -186,7 +186,7 @@ object CPArrayImage:
         val maxSz = lines.maxBy(_.size).size
         for line <- lines if line.size < maxSz do
             val d = maxSz - line.length
-            if align == -1 || align == 2then // Left align.
+            if align == -1 || align == 2 then // Left align.
                 (0 until d).foreach(_ => line += spacePx)
             else if align == 1 then // Right align.
                 (0 until d).foreach(_ => line.prepend(spacePx))


### PR DESCRIPTION
Edited because the spacing was wrong. In Metals it emits the following error.
```
scala.meta.tokenizers.TokenizeException: jar:file:///C:/Users/darren/AppData/Local/Coursier/cache/v1/https/repo1.maven.org/maven2/org/cosplayengine/cosplay/0.8.10/cosplay-0.8.10-sources.jar!/org/cosplay/CPArrayImage.scala:189: error: Invalid literal number
            if align == -1 || align == 2then // Left align.
```
